### PR TITLE
Don't add s3_bucket to physical path

### DIFF
--- a/irods_client_aws_lambda_s3.py
+++ b/irods_client_aws_lambda_s3.py
@@ -42,7 +42,7 @@ def lambda_handler(event, context):
                     # create collection
                     s3_prefix = os.path.dirname(s3_key)
                     s3_filename = os.path.basename(s3_key)
-                    physical_path_to_register_in_catalog = os.path.join('/', s3_bucket, s3_prefix, s3_filename)
+                    physical_path_to_register_in_catalog = os.path.join('/', s3_prefix, s3_filename)
                     irods_collection_name = os.path.join(irods_collection_prefix, s3_bucket, s3_prefix)
                     print(irods_collection_name)
                     session.collections.create(irods_collection_name, recurse=True)


### PR DESCRIPTION
We found that testing the lambda function for files registration  - files were registered with double bucket name as phycical path resulting in S3_FILE_STAT_ERR on attepmt to iget/irepl files.

It looks like s3_bucket is already factored into s3_prefix since
bucket name is the one and only directory in / - at least in our setup. Maybe this requires some if/else around.